### PR TITLE
Allow configuration via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 
 First, let's install psvm through npm : `npm install -g psvm`.
 
-FYI, psvm will create a directory `$HOME/.psvm` and will work in it.
+FYI, psvm will create a directory `$HOME/.psvm` and will work in it as the
+default directory. If you want to use a different directory, you can set an
+environment variable `PSVM_HOME`.
 
 It will :
-  * put versions of Purescript you download in `$HOME/.psvm/versions`
-  * put all bin files for the version you want to use in `$HOME/.psvm/current/bin`
+  * put versions of Purescript you download in `$HOME/.psvm/versions` (or `$PSVM_HOME/versions`, if `$PSVM_HOME` is set)
+  * put all bin files for the version you want to use in `$HOME/.psvm/current/bin` (or `$PSVM_HOME/current/bin`, if `$PSVM_HOME` is set)
 
 Because of the last point, it's necessary you add `$HOME/.psvm/current/bin` in your PATH.
 

--- a/src/paths.js
+++ b/src/paths.js
@@ -4,10 +4,16 @@ function getUserHome() {
   return process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'];
 }
 
-module.exports = {
-  PSVM_DIR: path.join(getUserHome(), '.psvm'),
-  PSVM_ARCHIVES: path.join(getUserHome(), '.psvm', 'archives'),
-  PSVM_VERSIONS: path.join(getUserHome(), '.psvm', 'versions'),
-  PSVM_CURRENT: path.join(getUserHome(), '.psvm', 'current'),
-  PSVM_CURRENT_BIN: path.join(getUserHome(), '.psvm', 'current', 'bin'),
+function getPsvmHome() {
+  return process.env.PSVM_HOME || path.join(getUserHome(), '.psvm');
 }
+
+var home = getPsvmHome();
+
+module.exports = {
+  PSVM_DIR: home,
+  PSVM_ARCHIVES: path.join(home, 'archives'),
+  PSVM_VERSIONS: path.join(home, 'versions'),
+  PSVM_CURRENT: path.join(home, 'current'),
+  PSVM_CURRENT_BIN: path.join(home, 'current', 'bin'),
+};


### PR DESCRIPTION
Use a PSVM_PREFIX environment variable, if one is set. This will be useful for me for pulp, as I want to use one version of `psc` for compiling Pulp (which is written in PureScript), and then use a different version of `psc` in the tests, and I would prefer it if the tests did not change anything outside their own directory.
