### PR TITLE
Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,6 @@ Let's run `psvm --help` to see what we can do:
 
 #### Note:
 
-* some old version of Purescript only offer the source code, they will not be installed.
-* For the moment, it has only been tested on a MacOS. It should be usable on Linux too, normally.
+* Some old versions of PureScript only offer the source code, they will not be installed.
+* psvm has been tested on 64-bit versions of Mac OS, Linux, and Windows.
 * psvm uses the GitHub API for some commands, which can lead to rate limiting, especially on CI services. If an environment variable `GITHUB_API_TOKEN` is set, it will be used for authenticating to the GitHub API.

--- a/src/lib.js
+++ b/src/lib.js
@@ -116,11 +116,18 @@ function use(version) {
 
 function getOSRelease() {
     var OSName = os.platform();
+    var OSArch = os.arch();
+
+    if (os.arch() !== 'x64') {
+        throw 'Unsupported CPU architecture (need x64; saw: ' + OSArch + ')';
+    }
 
     if (OSName === 'darwin') {
         return 'macos';
     } else if (OSName === 'linux') {
         return 'linux64';
+    } else if (OSName === 'win32') {
+        return 'win64';
     } else {
         throw "Unsupported OS, sorry. :(";
     }


### PR DESCRIPTION
This seems to work on Pulp's Windows CI (which uses Appveyor); you can see it in action here: https://ci.appveyor.com/project/bodil/pulp