### PR TITLE
Hard code tar 2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "nugget": "^1.5.4",
     "ramda": "^0.17.1",
     "rimraf": "^2.4.2",
-    "tarball-extract": "0.0.3"
+    "tarball-extract": "0.0.3",
+    "tar": "2.2.1"
   }
 }


### PR DESCRIPTION
I was reinstalling PureScript and ran into this error.

```bash
> psvm install-latest
Downloading PureScript compiler  v0.11.4  for  linux64
Extracting  ...
(node:13065) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): TypeError: tar.Extract is not a function
```
Looks like `tarball-extract` is relying on tar *, and tar's API just changed recently.

https://github.com/joshuah/tarball-extract/issues/8
Related: https://github.com/konsumer/easy-ffmpeg/issues/7

I installed the repo locally and hard coded the tar dependency and everything seems to work now.